### PR TITLE
Łączenie się z backendem poprzez proxy, zamiast przez CORS

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -362,16 +362,15 @@ module.exports = function(grunt) {
                 }
             },
             proxies: [{
-                context: '/openpkw-dokument-generator',
+                context: '/api',
                 host: config.backendProxy,
                 port: 9080,
                 https: false,
                 xforward: false,
                 rewrite: {
-                    '^(\/openpkw-dokument-generator[/]{0,1})(.*)$': '/openpkw-dokument-generator/$2'
+                    '^(\/api[/]{0,1})(.*)$': '/$2'
                 }
             }]
-
         },
 
         scp: {

--- a/src/es2015/components/chart/chart-data.service.js
+++ b/src/es2015/components/chart/chart-data.service.js
@@ -9,7 +9,7 @@ class ChartDataService {
 
     loadPollingData() {
         var deferred = Q.get(ChartDataService.instance).defer();
-        ChartDataService.instance.data = HTTP.get(ChartDataService.instance).get('http://rumcajs.open-pkw.pl:9080/openpkw/votes').then((data) => {
+        ChartDataService.instance.data = HTTP.get(ChartDataService.instance).get('/api/openpkw/votes').then((data) => {
             deferred.resolve(data);
             return deferred.promise;
         });

--- a/src/es2015/components/main/district-data.service.js
+++ b/src/es2015/components/main/district-data.service.js
@@ -9,7 +9,7 @@ class DistrictDataService {
 
     loadTableData() {
         var deferred = Q.get(DistrictDataService.instance).defer();
-        DistrictDataService.instance.data = HTTP.get(DistrictDataService.instance).get('http://rumcajs.open-pkw.pl:9080/openpkw/districts').then((data) => {
+        DistrictDataService.instance.data = HTTP.get(DistrictDataService.instance).get('/api/openpkw/districts').then((data) => {
             var districts = data.data.districts;
             var result = new Map();
             for (let district of districts) {


### PR DESCRIPTION
Zmiany obejmują trzy projekty:
- openpkw-devops
- openpkw-weryfikator-frontend
- openpkw-weryfikator-backend

W projekcie openpkw-weryfikator-frontend są dwie zmiany:
1. Konfiguracja proxy w node.js do testowania lokalnego (przy pomocy npm run server-dev).
2. Zamiana linków bezwzględnych do backendu na linki względne do proxy.
